### PR TITLE
Change Sony Vegas to Vegas Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@
 - ✨ Olive *(Windows, Mac, Linux)*
 - ✨ Kdenlive *(Windows, Mac, Linux)*
 - ⭐️ (💵) DaVinci Resolve *(Windows, Mac, Linux)*
-- 💵 Sony Vegas *(Windows)*
+- 💵 Vegas Pro *(Windows)*
 - 💵 Final Cut Pro X *(Mac)*
 - 🔒 Kapwing *(Windows, Mac, Linux)*
 


### PR DESCRIPTION
Vegas was sold by Sony years ago to Magix, and thus it has not been called Sony Vegas since. It's now officially called Vegas Pro or just Vegas.