### PR TITLE
Removed Figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@
 
 - ✨ Penpot *(Windows, Mac, Linux)*
 - ✨ Draftoola *(Linux)*
-- 🔒 Figma *(Windows, Mac, Linux)*
 - 🔒 Framer *(Windows, Mac, Linux)*
 - 💵 Sketch *(Mac)*
 - 💵 Lunacy *(Windows, Mac, Linux)*


### PR DESCRIPTION
Adobe has announced the intent to aquire Figma in 2022.

https://www.adobe.com/about-adobe/intent-to-acquire-20220915.html