### PR TITLE
Update links for Cakewalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@
 
 - ✨ (💵, 🔒) [Ardour](https://ardour.org/) *(Windows, Mac, Linux)*
 - ✨ [LMMS](https://lmms.io/) *(Windows, Mac, Linux)*
-- ⭐️ [Cakewalk](https://www.bandlab.com/products/cakewalk) *(Windows)*
+- ⭐️ [Cakewalk by Bandlab](https://www.bandlab.com/products/cakewalk) *(Windows)*
 - ⭐️ [GarageBand](https://www.apple.com/mac/garageband/) *(Mac)*
 - ⭐️ (💵) [Tracktion](https://www.tracktion.com/) *(Windows, Mac, Linux)*
 - ⭐️ (💵) [Pro Tools](https://www.avid.com/pro-tools) *(Windows, Mac)*
@@ -209,6 +209,8 @@
 - 💵 [Ableton Live](https://www.ableton.com/en/live/) *(Windows, Mac)*
 - 💵 [FL Studio](https://www.image-line.com/) *(Windows, Mac, Android)*
 - 🔒 [Studio One](https://www.presonus.com/en-US/studio-one.html) *(Windows, Mac)*
+- 🔒 [Cakewalk Next](https://www.cakewalk.com) *(Windows)*
+- 🔒 [Cakewalk Sonar](https://www.bandlab.com) *(Windows)*
 
 ## After Effects
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@
 - 💵 [FL Studio](https://www.image-line.com/) *(Windows, Mac, Android)*
 - 🔒 [Studio One](https://www.presonus.com/en-US/studio-one.html) *(Windows, Mac)*
 - 🔒 [Cakewalk Next](https://www.cakewalk.com) *(Windows)*
-- 🔒 [Cakewalk Sonar](https://www.bandlab.com) *(Windows)*
+- 🔒 [Cakewalk Sonar](https://www.cakewalk.com) *(Windows)*
 
 ## After Effects
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@
 
 - ✨ (💵, 🔒) [Ardour](https://ardour.org/) *(Windows, Mac, Linux)*
 - ✨ [LMMS](https://lmms.io/) *(Windows, Mac, Linux)*
-- ⭐️ [Cakewalk](https://www.cakewalk.com/) *(Windows)*
+- ⭐️ [Cakewalk](https://www.bandlab.com/products/cakewalk) *(Windows)*
 - ⭐️ [GarageBand](https://www.apple.com/mac/garageband/) *(Mac)*
 - ⭐️ (💵) [Tracktion](https://www.tracktion.com/) *(Windows, Mac, Linux)*
 - ⭐️ (💵) [Pro Tools](https://www.avid.com/pro-tools) *(Windows, Mac)*


### PR DESCRIPTION
The current link for Cakewalk points to the site for Cakewalk Next and Cakewalk Sonar, which are both in early access and require a Bandlab membership (subscription). I've updated the links to reflect this.

I've also add a link to the previous free version of Cakewalk, Cakewalk by Bandlab, to the list.