### PR TITLE
Add Darkroom under Lightroom alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 - ✨ [RawTherapee](https://www.rawtherapee.com/) *(Windows, Mac, Linux)*
 - ✨ [Darktable](https://www.darktable.org/) *(Windows, Mac, Linux)*
 - ✨ [digiKam](https://www.digikam.org/) *(Windows, Mac, Linux)*
+- ⭐️ (💵, 🔒) [Darkroom](https://darkroom.co/) *(Mac, iOS)*
 - 💵 [On1](https://www.on1.com/) *(Windows, Mac, Linux)*
 - 💵 [FastRawViewer](https://www.fastrawviewer.com/) *(Windows, Mac)*
 - 💵 [Capture One](https://www.captureone.com/en) *(Windows, Mac)*


### PR DESCRIPTION
Hey! I'd like to add [Darkroom](https://darkroom.co/) as a Lightroom alternative to the list. It's a Mac and iOS app for managing and processing photos. The free version is pretty useful in itself, and there are both one-time purchase and subscription options. The premium version unlocks a few more advanced tools, as well as lightweight video editing. I've been using it for a few years and, while it might not have every feature that a professional photographer needs, you can get pretty good results very quickly even with just the free version. Thanks for considering!