### PR TITLE
Add Moving Pencils as Illustrator alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 
 #### General
 - ✨ [Inkscape](https://inkscape.org/) *(Windows, Mac, Linux)*
+- ⭐️ [Moving Pencils](https://movingpencils.com/) *(Browser)*
 - ⭐️ [Boxy SVG](https://boxy-svg.com/) *(Browser)*
 - 💵 [Corel Draw](https://www.coreldraw.com/) *(Windows, Mac)*
 - 💵 [Affinity Designer](https://affinity.serif.com/en-us/) *(Windows, Mac, iOS)*


### PR DESCRIPTION
I've added movingpencils.com as an Adobe Illustrator alternative. It is the only free browser-based vector editor with support for Illustrator-like Pathfinder tools.