### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@
 - ✨ [Kdenlive](https://kdenlive.org/en/) *(Windows, Mac, Linux)*
 - ✨ [OpenShot](https://www.openshot.org/) *(Windows, Mac, Linux)*
 - ✨ [Shotcut](https://www.shotcut.org/) *(Windows, Mac, Linux)*
+- ✨ [Handbrake](https://handbrake.fr/) *(Windows, Mac, Linux)*
 - ⭐️ (💵) [DaVinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) *(Windows, Mac, Linux)*
 - 💵 (or 🔒) [VEGAS Pro](https://www.vegascreativesoftware.com/us/vegas-pro/)  *(Windows)*
 - 💵 [Final Cut Pro](https://www.apple.com/final-cut-pro/) *(Mac, iOS)*
@@ -174,7 +175,7 @@
 - ✨ [LibreOffice Draw](https://www.libreoffice.org/) *(Windows, Mac, Linux)*
 - ⭐️ [PDF24](https://www.pdf24.org/en/) *(Windows)*
 - 💵 [PDF-XChange](https://pdf-xchange.eu/pdf-xchange-editor/) *(Windows)*
-- 🔒 [Xodo](https://xodo.com/) *(Browser)*
+- 🔒 [Xodo](https://xodo.com/) *(Browser)
 
 #### Reader
 


### PR DESCRIPTION
Added one open-source video converter to that list. Unfortunately, there's no other option instead of Adobe Premiere where to add that, if you'd refer me, I'll be happy to move it there. This one could be alternative to Adobe Media Encoder. 

Their github:
https://github.com/HandBrake/HandBrake