### PR TITLE
Updated platforms for Affinity Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@
 
 - ✨ [Scribus](https://www.scribus.net) *(Windows, Mac, Linux)*
 - ✨ [Laidout](https://laidout.org) *(Linux)*
-- 💵 [Affinity Publisher](https://affinity.serif.com/en-gb/publisher) *(Windows, Mac)*
+- 💵 [Affinity Publisher](https://affinity.serif.com/en-gb/publisher) *(Windows, Mac, iOS)*
 - 💵 [QuarkXPress](https://www.quark.com/products/quarkxpress) *(Windows, Mac)*
 
 ## Substance


### PR DESCRIPTION
added iOS to the list of platforms Affinity Publisher supports: https://affinity.serif.com/en-gb/publisher/ipad/