### PR TITLE
Remove [Vegas Effects] as it was discontinued and no longer purchasable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@
 - ✨ [Blender](https://www.blender.org) *(Windows, Mac, Linux)*
 - ⭐️ (💵) [DaVinci Resolve Fusion](https://www.blackmagicdesign.com/nl/products/davinciresolve/fusion) *(Windows, Mac, Linux)*
 - ⭐️ (💵) [HitFilm](https://fxhome.com/product/hitfilm) *(Windows, Mac, Linux)*
-- 💵 [VEGAS Effects](https://www.vegascreativesoftware.com/au/vegas-post) *(Windows)*
 - ⭐️ [Unreal Engine](https://www.unrealengine.com) (Motion Graphics Tools) *(Windows, Mac, Linux)*
 
 ### Motion graphics


### PR DESCRIPTION
Remove [Vegas Effects] as it was discontinued.

Copy of the text of the email sent out to all VPro Post subscribers:

> As you may have already heard, VEGAS Pro Post will be discontinued with the release of VEGAS Pro 22. Because we appreciate your loyalty to VEGAS Pro, we are happy to offer two options for you to continue using your software:
> 
> Keep your current VEGAS Pro Post contract
> 
> You will continue to receive the latest version of VEGAS Pro when it is released but no updates for VEGAS Effects, VEGAS Image, or Boris FX Primatte Studio
> 
> Version 22 will not support interaction between VEGAS Pro, Effects, and Image, but you can still use those applications as stand-alone. You can use versions 21 and 22 simultaneously, and the interoperation works as usual with version 21.
> 
> 
> OR switch to VEGAS Pro Suite 365 for a special price
> 
> Receive the latest version of VEGAS Pro when it is released
> 
> Receive all of the Suite bundle products, including the latest versions of Mocha VEGAS, SOUND FORGE Pro 365, ACID Pro 365, and more
> 
> Keep your current quotas for VEGAS Hub features
> 
> Receive FREE perpetual versions of VEGAS Pro 21, VEGAS Effects, and VEGAS Image so you can continue using those products without interruption
> 
> 
> If you choose the first option above, you don’t need to do anything. If you decide to switch to VEGAS Pro Suite 365, please contact our Sales Support team at infoservice@magix.net with the subject line "Switch to VEGAS Pro Suite 365".
>  
> Thank you!
> 
> Your VEGAS Pro Team

Source - https://www.vegascreativesoftware.info/us/forum/if-i-upgrade-to-vegas-pro-22-can-i-still-use-vegas-effects--146666/#:~:text=vkmast%20wrote%20on%207/29/2024%2C