### PR TITLE
Update README.md: armorpaint

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@
 
 ### Painter
 
-- ✨ [ArmorPaint](https://armorpaint.org) *(Windows, Mac, Linux, iOS, Android)*
+- ✨ (💵) [ArmorPaint](https://armorpaint.org) *(Windows, Mac, Linux, iOS, Android)*
 - ⭐️ [Quixel Mixer](https://quixel.com/mixer) *(Windows, Mac)*
 - 💵 [3DCoat](https://3dcoat.com) *(Windows, Mac, Linux)*
 - 💵 (or 🔒) [Marmoset Toolbag](https://marmoset.co/toolbag) *(Windows, Mac)*


### PR DESCRIPTION
i notice that recent desktop versions of armorpaint (including mobile ones), appear to have a one-time purchase on their page, despite it being open-source.
not sure if that would be added to the readme to avoid confusion.
i set the one-time purchase icon in brackets just in case.