### PR TITLE
Mark Cockos' Reaper and FL Studio more correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,10 @@
 - ⭐️ [GarageBand](https://www.apple.com/mac/garageband) *(Mac)*
 - ⭐️ (💵) [Tracktion](https://www.tracktion.com) *(Windows, Mac, Linux)*
 - ⭐️ (🔒) [Pro Tools](https://www.avid.com/pro-tools) *(Windows, Mac)*
-- 💵 [Reaper](https://www.reaper.fm) *(Windows, Mac, Linux)*
+- ⭐️ (💵) [Reaper](https://www.reaper.fm) *(Windows, Mac, Linux)*
 - 💵 [Logic Pro](https://www.apple.com/logic-pro) *(Mac, iOS)*
 - 💵 [Ableton Live](https://www.ableton.com/en/live) *(Windows, Mac)*
-- 💵 [FL Studio](https://www.image-line.com/fl-studio) *(Windows, Mac)*
+- ⭐️ (💵) [FL Studio](https://www.image-line.com/fl-studio) *(Windows, Mac)*
 - 💵 [FL Studio Mobile](https://www.image-line.com/fl-studio-mobile) *(Windows, Mac, Android, iOS)*
 - 💵 [Bitwig](https://www.bitwig.com) *(Windows, Mac, Linux)*
 - 💵 [Steinberg Wavelab](https://www.steinberg.net/wavelab) *(Windows, Mac)*


### PR DESCRIPTION
Cockos Reaper can be used without paying a single cent. The only thing that changes after 90 days of evaluation is that a purchase nag (similar to WinRaR) starts appearing on launch (once every 24h, i think), you can skip it after 5 seconds of waiting and continue to use all features of Reaper.

FL Studio is a bit more complicated, you technically can just use the Demo version of it, but it's not as powerful as the full version. You can't save/load your own projects (FLPs) in Demo version, but you still can make music. Although, considering how often some VSTs make FL crash you might not get too far.
Not sure about what to do with FL Studio, because you can _technically_ use it for free, but it's not a pleasant experience.