### PR TITLE
Mark Unreal Engine as TECHNICALLY open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@
 - ⭐️ (💵) [DaVinci Resolve Fusion](https://www.blackmagicdesign.com/nl/products/davinciresolve/fusion) *(Windows, Mac, Linux)*
 - ⭐️ (💵) [HitFilm](https://fxhome.com/product/hitfilm) *(Windows, Mac, Linux)*
 - 💵 [VEGAS Effects](https://www.vegascreativesoftware.com/au/vegas-post) *(Windows)*
-- ⭐️ [Unreal Engine](https://www.unrealengine.com) (Motion Graphics Tools) *(Windows, Mac, Linux)*
+- ⭐️ (✨) [Unreal Engine](https://www.unrealengine.com) (Motion Graphics Tools) *(Windows, Mac, Linux)*
 
 ### Motion graphics
 


### PR DESCRIPTION
Unreal Engine's full source is available to all members of EpicGames organization on GitHub, so it's TECHNICALLY open-source. Becoming a member is easy, and, moreover, is actually required for some ways of obtaining Unreal Engine (i.e. from AUR)

This is a technicality, moreover, Unreal Engine actually requires you to sign a EULA anyway, so this complicates things