### PR TITLE
Readd EmbedPDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@
 - ✨ [Okular](https://okular.kde.org/) *(Windows, Linux)*
 - ✨ [Evince](https://wiki.gnome.org/Apps/Evince) *(Windows, Linux)*
 - ✨ [XPDFReader](https://www.xpdfreader.com/index.html) *(Windows, Linux)*
+- ✨ [EmbedPDF](https://www.embedpdf.com) *(Browser)*
 
 ## Bridge
 


### PR DESCRIPTION
It seems it was accidentally removed in https://github.com/KenneyNL/Adobe-Alternatives/commit/46d5605f1550e4308b101f37dc52ca8b7859b340

This is an open source (MIT) project available here: https://github.com/embedpdf/embed-pdf-viewer

Related to: https://github.com/KenneyNL/Adobe-Alternatives/issues/194