### PR TITLE
Affinity update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - ⭐️ (💵, 🔒) [Sumo Paint](https://sumo.app) *(Windows, macOS, Linux)*
 - ⭐️ (💵, 🔒) [Sumopaint](https://paint.sumo.app) *(Browser, Windows, macOS, Linux)*
 - ⭐️ (🔒) [Pixlr](https://pixlr.com) *(Browser)*
-- ⭐️ [Affinity](https://www.affinity.studio/) *(Windows, macOS, iOS(under development))*
+- ⭐️ (🔒) [Affinity](https://www.affinity.studio/) *(Windows, macOS, iOS(under development))*
 - 💵 [Pixelmator Pro](https://www.pixelmator.com/pro) *(macOS)*
 - 💵 [PaintShop Pro](https://www.paintshoppro.com) *(Windows)*
 - 💵 [Photoline](https://www.pl32.com) *(Windows, macOS)*


### PR DESCRIPTION
corrected a misspelled word and added the (🔒) since accessing AI-powered features (like generative fill, background removal) require a Canva Pro subscription.