### PR TITLE
Add Photoscape (Photography) to the list of Adobe Alternatives.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@
 - ⭐️ (💵, 🔒) [Sumopaint](https://paint.sumo.app) *(Browser, Windows, macOS, Linux)*
 - ⭐️ (🔒) [Pixlr](https://pixlr.com) *(Browser)*
 - ⭐️ (🔒) [Affinity](https://www.affinity.studio/) *(Windows, macOS, iOS(under development))*
+- ⭐️ (🔒)[PhotoScape](http://www.photoscape.org/ps/main/index.php) *(Windows, macOS)*
 - 💵 [Pixelmator Pro](https://www.pixelmator.com/pro) *(macOS)*
 - 💵 [PaintShop Pro](https://www.paintshoppro.com) *(Windows)*
 - 💵 [Photoline](https://www.pl32.com) *(Windows, macOS)*
 - 💵 [Acorn](https://flyingmeat.com/acorn) *(macOS)*
+
 
 ### Painting
 


### PR DESCRIPTION
I've added another alternative tool to the list of Adobe alternatives. The tool is a photography category, and it has a free version and a pro version with more features.
Name: PhotoScape