### PR TITLE
Update README.md (ArmorLab -> ArmorPaint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@
 ### Designer
 
 - ✨ [Material Maker](https://www.materialmaker.org) *(Windows, macOS, Linux)*
-- ✨ [ArmorLab](https://armorlab.org/) *(Windows, macOS, Linux)*
+- ✨ [ArmorPaint](https://armorpaint.org/) *Previously known as ArmorLab (Windows, macOS, Linux)*
 - ⭐️ [Quixel Mixer](https://quixel.com/mixer) *(Windows, macOS)*
 - ⭐️ [InstaMAT](https://instamaterial.com) *(Windows, macOS)*
 - ⭐️ [PixaFlux](http://pixaflux.com/index.html) *(Windows, macOS)*


### PR DESCRIPTION
There must've been some naming changes, cause ArmorLab.org now links to some gambling slot machine tutorials.