### PR TITLE
Add PhotoQuill to Photoshop alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 - ✨ [digiKam](https://www.digikam.org/) *(Windows, macOS, Linux)*
 - ⭐️ (💵) [Paint.NET](https://www.getpaint.net/) *(Windows)*
 - ⭐️ (💵) [Photopea](https://www.photopea.com) *(Browser)*
+- ⭐️ [PhotoQuill](https://photoquill.com) *(Browser)*
 - ⭐️ (💵, 🔒) [Sumo Paint](https://sumo.app) *(Windows, macOS, Linux)*
 - ⭐️ (💵, 🔒) [Sumopaint](https://paint.sumo.app) *(Browser, Windows, macOS, Linux)*
 - ⭐️ (🔒) [Pixlr](https://pixlr.com) *(Browser)*


### PR DESCRIPTION
Link: https://photoquill.com/

Adds PhotoQuill as a free browser-based Photoshop alternative in the Photoshop photography section.